### PR TITLE
Amd64 vs arm64

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
-inbucket_version: '2.1.0'
+inbucket_version: '3.0.1-rc2'
 inbucket_loglevel: warn
 inbucket_smtp_addr: '0.0.0.0:2500'
 inbucket_pop3_addr: '0.0.0.0:1100'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,4 +1,14 @@
+- name: Set arm64 architecture
+  set_fact:
+    inbucket_arch: arm64
+  when: ansible_facts['ansible_architecture'] == "aarch64"
+
+- name: Set arm64 architecture
+  set_fact:
+    inbucket_arch: amd64
+  when: ansible_facts['ansible_architecture'] != "aarch64"
+
 - name: Install Inbucket
   ansible.builtin.apt:
-    deb: "https://github.com/inbucket/inbucket/releases/download/v{{ inbucket_version }}/inbucket_{{ inbucket_version }}_linux_amd64.deb"
+    deb: "https://github.com/inbucket/inbucket/releases/download/v{{ inbucket_version }}/inbucket_{{ inbucket_version }}_linux_{{ inbucket_arch }}.deb"
   notify: restart inbucket


### PR DESCRIPTION
This just allows us to use either the ARM or AMD binaries when installing